### PR TITLE
パラメータの置換と、パラメータの取得

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,207 @@ spec/example_input/tmp
 .idea/
 docx_templater*gem
 Gemfile.lock
+### Ruby template
+*.gem
+*.rbc
+/.config
+/coverage/
+/InstalledFiles
+/pkg/
+/spec/reports/
+/spec/examples.txt
+/test/tmp/
+/test/version_tmp/
+/tmp/
+
+# Used by dotenv library to load environment variables.
+# .env
+
+# Ignore Byebug command history file.
+.byebug_history
+
+## Specific to RubyMotion:
+.dat*
+.repl_history
+build/
+*.bridgesupport
+build-iPhoneOS/
+build-iPhoneSimulator/
+
+## Specific to RubyMotion (use of CocoaPods):
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# vendor/Pods/
+
+## Documentation cache and generated files:
+/.yardoc/
+/_yardoc/
+/doc/
+/rdoc/
+
+## Environment normalization:
+/.bundle/
+/vendor/bundle
+/lib/bundler/man/
+
+# for a library or gem, you might want to ignore these files since the code is
+# intended to run in multiple environments; otherwise, check them in:
+# Gemfile.lock
+# .ruby-version
+# .ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc
+
+# Used by RuboCop. Remote config files pulled in from inherit_from directive.
+# .rubocop-https?--*
+
+### Rails template
+*.rbc
+capybara-*.html
+.rspec
+/db/*.sqlite3
+/db/*.sqlite3-journal
+/db/*.sqlite3-[0-9]*
+/public/system
+/coverage/
+/spec/tmp
+*.orig
+rerun.txt
+pickle-email-*.html
+
+# Ignore all logfiles and tempfiles.
+/log/*
+/tmp/*
+!/log/.keep
+!/tmp/.keep
+
+# TODO Comment out this rule if you are OK with secrets being uploaded to the repo
+config/initializers/secret_token.rb
+config/master.key
+
+# Only include if you have production secrets in this file, which is no longer a Rails default
+# config/secrets.yml
+
+# dotenv, dotenv-rails
+# TODO Comment out these rules if environment variables can be committed
+.env
+.env.*
+
+## Environment normalization:
+/.bundle
+/vendor/bundle
+
+# these should all be checked in to normalize the environment:
+# Gemfile.lock, .ruby-version, .ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc
+
+# if using bower-rails ignore default bower_components path bower.json files
+/vendor/assets/bower_components
+*.bowerrc
+bower.json
+
+# Ignore pow environment settings
+.powenv
+
+# Ignore Byebug command history file.
+.byebug_history
+
+# Ignore node_modules
+node_modules/
+
+# Ignore precompiled javascript packs
+/public/packs
+/public/packs-test
+/public/assets
+
+# Ignore yarn files
+/yarn-error.log
+yarn-debug.log*
+.yarn-integrity
+
+# Ignore uploaded files in development
+/storage/*
+!/storage/.keep
+/public/uploads
+
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+shoho.docx
+simplest.docx

--- a/lib/docx_templater/docx_creator.rb
+++ b/lib/docx_templater/docx_creator.rb
@@ -1,5 +1,7 @@
 require 'zip'
 
+DOCUMENT_XML = 'word/document.xml'
+
 module DocxTemplater
   class DocxCreator
     attr_reader :template_path, :template_processor
@@ -26,10 +28,9 @@ module DocxTemplater
     end
 
     private
-
     def copy_or_template(entry_name, entry_bytes)
       # Inside the word document archive is one file with contents of the actual document. Modify it.
-      if entry_name == 'word/document.xml'
+      if entry_name == DOCUMENT_XML
         template_processor.render(entry_bytes)
       else
         entry_bytes

--- a/lib/docx_templater/template_processor.rb
+++ b/lib/docx_templater/template_processor.rb
@@ -13,79 +13,28 @@ module DocxTemplater
     def render(document)
       document.force_encoding(Encoding::UTF_8) if document.respond_to?(:force_encoding)
       data.each do |key, value|
-        case value
-        when Array
-          document = enter_multiple_values(document, key)
-          document.gsub!("#SUM:#{key.to_s.upcase}#", value.count.to_s)
-        when TrueClass, FalseClass
-          if value
-            document.gsub!(/\#(END)?IF:#{key.to_s.upcase}\#/, '')
-          else
-            document.gsub!(/\#IF:#{key.to_s.upcase}\#.*\#ENDIF:#{key.to_s.upcase}\#/m, '')
-          end
-        else
-          document.gsub!("$#{key.to_s.upcase}$", safe(value))
-        end
+        document.gsub!("$#{key.to_s.upcase}$", safe(value))
       end
       document
     end
 
-    private
+    def self.scan_params template_path
+      document = Zip::File.open(template_path)
+                   .select { |entry| entry.name == DOCUMENT_XML }
+                   .first
+                   .get_input_stream
+                   .read
+      document.force_encoding(Encoding::UTF_8) if document.respond_to?(:force_encoding)
+      document.scan(/\$([A-Z]+_\d+)\$/).flatten
+    end
 
+    private
     def safe(text)
       if escape_html
         text.to_s.gsub('&', '&amp;').gsub('>', '&gt;').gsub('<', '&lt;')
       else
         text.to_s
       end
-    end
-
-    def enter_multiple_values(document, key)
-      DocxTemplater.log("enter_multiple_values for: #{key}")
-      # TODO: ideally we would not re-parse xml doc every time
-      xml = Nokogiri::XML(document)
-
-      begin_row = "#BEGIN_ROW:#{key.to_s.upcase}#"
-      end_row = "#END_ROW:#{key.to_s.upcase}#"
-      begin_row_template = xml.xpath("//w:tr[contains(., '#{begin_row}')]", xml.root.namespaces).first
-      end_row_template = xml.xpath("//w:tr[contains(., '#{end_row}')]", xml.root.namespaces).first
-      DocxTemplater.log("begin_row_template: #{begin_row_template}")
-      DocxTemplater.log("end_row_template: #{end_row_template}")
-      raise "unmatched template markers: #{begin_row} nil: #{begin_row_template.nil?}, #{end_row} nil: #{end_row_template.nil?}. This could be because word broke up tags with it's own xml entries. See README." unless begin_row_template && end_row_template
-
-      row_templates = []
-      row = begin_row_template.next_sibling
-      while row != end_row_template
-        row_templates.unshift(row)
-        row = row.next_sibling
-      end
-      DocxTemplater.log("row_templates: (#{row_templates.count}) #{row_templates.map(&:to_s).inspect}")
-
-      # for each data, reversed so they come out in the right order
-      data[key].reverse_each do |each_data|
-        DocxTemplater.log("each_data: #{each_data.inspect}")
-
-        # dup so we have new nodes to append
-        row_templates.map(&:dup).each do |new_row|
-          DocxTemplater.log("   new_row: #{new_row}")
-          innards = new_row.inner_html
-          matches = innards.scan(/\$EACH:([^\$]+)\$/)
-          unless matches.empty?
-            DocxTemplater.log("   matches: #{matches.inspect}")
-            matches.map(&:first).each do |each_key|
-              DocxTemplater.log("      each_key: #{each_key}")
-              innards.gsub!("$EACH:#{each_key}$", safe(each_data[each_key.downcase.to_sym]))
-            end
-          end
-          # change all the internals of the new node, even if we did not template
-          new_row.inner_html = innards
-          # DocxTemplater::log("new_row new innards: #{new_row.inner_html}")
-
-          begin_row_template.add_next_sibling(new_row)
-        end
-      end
-      (row_templates + [begin_row_template, end_row_template]).each(&:unlink)
-      xml.to_s
     end
   end
 end

--- a/lib/docx_templater/template_processor.rb
+++ b/lib/docx_templater/template_processor.rb
@@ -25,7 +25,7 @@ module DocxTemplater
                    .get_input_stream
                    .read
       document.force_encoding(Encoding::UTF_8) if document.respond_to?(:force_encoding)
-      [document.scan(/\$([A-Z]+_\d+)\$/), document.scan(/\$([A-Z]+_[A-Z]+_\d+)\$/)].flatten
+      document.scan(/\$([A-Z_\d+]+)\$/).flatten
     end
 
     private

--- a/lib/docx_templater/template_processor.rb
+++ b/lib/docx_templater/template_processor.rb
@@ -25,7 +25,7 @@ module DocxTemplater
                    .get_input_stream
                    .read
       document.force_encoding(Encoding::UTF_8) if document.respond_to?(:force_encoding)
-      document.scan(/\$([A-Z]+_\d+)\$/).flatten
+      [document.scan(/\$([A-Z]+_\d+)\$/), document.scan(/\$([A-Z]+_[A-Z]+_\d+)\$/)].flatten
     end
 
     private


### PR DESCRIPTION
## 仕様変更前

### `TemplateProcessor#render`

このメソッドは初期化のときに渡されたパラメータを置換するメソッド

- 対応していたパラメータ `$#SUM:パラメータ` `#IF:パラメータ` `#(END)?IF:パラメータ` `$パラメータ$`

## 仕様変更後

### `TemplateProcessor#render`

不必要な置換パラメータ引数を消した

- 対応するパラメータ`$パラメータ$`

### `TemplateProcessor.scan_params`

引数のwordのパスを受け取って、文書内にある

- `$パラメータ_NUM$`と `$パラメータ_パラメータ_NUM$`

の文字列を取り出すメソッドを追加した